### PR TITLE
Add default options

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,5 +9,8 @@
       "description": "prefix for your images in the target registry (i.e. GCP project ID)",
       "required": false
     }
+  },
+  "options": {
+    "allow-unauthenticated": true
   }
 }


### PR DESCRIPTION
Currently there is a sigsegv and a panic when this scirpt is invoked as
the script is expecting the (supposedly) optional param of options.

This commit adds it with default values This should allow the application to
iterate through cleanly.