### PR TITLE
Allowed empty scope in tokenProxyHandler

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,9 +148,6 @@ func tokenProxyHandler(tokenEndpoint, repoPrefix string) http.HandlerFunc {
 
 			q := r.URL.Query()
 			scope := q.Get("scope")
-			if scope == "" {
-				return
-			}
 			newScope := strings.Replace(scope, "repository:", fmt.Sprintf("repository:%s/", repoPrefix), 1)
 			q.Set("scope", newScope)
 			u, _ := url.Parse(tokenEndpoint)


### PR DESCRIPTION
I am using this proxy for a [Harbor](https://goharbor.io/) registry and as it is deployed, there is no scope sent for auth. I'm not sure what the reason was for exiting early when the scope is empty but it works in my testing with harbor with the empty string.